### PR TITLE
Fix e2e install test: app has 3 settings screens, not 4

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@crowdstrike/foundry-playwright": "0.5.0",
-        "@types/node": "latest"
+        "@types/node": "25.6.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -130,13 +130,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/commander": {
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/tests/app-install.setup.ts
+++ b/e2e/tests/app-install.setup.ts
@@ -30,15 +30,8 @@ setup('install app', async ({ page }) => {
       await page.getByRole('textbox', { name: 'Workday tenant Id (Generate access token)' }).fill('test-tenant-id');
       await page.getByRole('textbox', { name: 'Refresh token' }).fill('test-refresh-token');
       await page.getByRole('textbox', { name: 'Workday tenant Id (Get leavers data)' }).fill('test-tenant-id');
-      await nextButton.click();
-      await page.waitForLoadState('domcontentloaded').catch(() => {});
 
-      // Screen 4: Setting 4 — same fields as Screen 3 (Target Groups pre-filled)
-      await page.getByRole('textbox', { name: 'Workday tenant Id (Generate access token)' }).fill('test-tenant-id');
-      await page.getByRole('textbox', { name: 'Refresh token' }).fill('test-refresh-token');
-      await page.getByRole('textbox', { name: 'Workday tenant Id (Get leavers data)' }).fill('test-tenant-id');
-
-      // "Install app" button is visible on Screen 4
+      // "Install app" button is visible on Screen 3
     },
   });
 });


### PR DESCRIPTION
The install wizard has 3 settings screens but the e2e test was configured for 4. After filling Screen 3, the test clicked "Next setting" which doesn't exist on the last screen (only "Install app" is available), causing a 45-second timeout waiting for a button that never appears.

Removed the `nextButton.click()` after Screen 3 and removed the entire Screen 4 block since it was a duplicate of Screen 3's fields.