### PR TITLE
Upgrade @crowdstrike/foundry-playwright to 0.5.1

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.0",
+        "@crowdstrike/foundry-playwright": "0.5.1",
         "@types/node": "25.6.0"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.0.tgz",
-      "integrity": "sha512-0dKup8mOEVT5KKJezfYVskOgk1zDh6MONyQ1EBdkQ4l1HfMbloZEJ4eMK+Opgww28yMCjhgsyuKp/qq4xmzURg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.1.tgz",
+      "integrity": "sha512-aB74uvvvfrOkHvy3jVfpeO3JPOjPdNHuMR+bUZyqUknFtZ4jBtquQMGWumspbXS+P78vDuI8c8BTVilnI2sscA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.0",
+    "@crowdstrike/foundry-playwright": "0.5.1",
     "@types/node": "25.6.0"
   }
 }

--- a/e2e/tests/app-install.setup.ts
+++ b/e2e/tests/app-install.setup.ts
@@ -12,26 +12,31 @@ setup('install app', async ({ page }) => {
     configureSettings: async (page) => {
       const nextButton = page.getByRole('button', { name: 'Next setting' });
 
-      // Screen 1: Workday get leavers data — Name, Workday host
-      await page.getByRole('textbox', { name: 'Name' }).fill('Workday Get Leavers');
-      await page.getByRole('textbox', { name: 'Workday host' }).fill('https://wd2-impl.workday.com');
-      await nextButton.click();
-      await page.waitForLoadState('domcontentloaded').catch(() => {});
+      // Fill each settings screen in whatever order the app presents them.
+      // Detect the current screen by checking for a unique field.
+      for (let screen = 0; screen < 3; screen++) {
+        if (await page.getByRole('textbox', { name: 'Workday tenant Id (Generate access token)' }).isVisible({ timeout: 3000 }).catch(() => false)) {
+          // Configuration 1 screen — tenant IDs, refresh token (Target Groups pre-filled)
+          await page.getByRole('textbox', { name: 'Workday tenant Id (Generate access token)' }).fill('test-tenant-id');
+          await page.getByRole('textbox', { name: 'Refresh token' }).fill('test-refresh-token');
+          await page.getByRole('textbox', { name: 'Workday tenant Id (Get leavers data)' }).fill('test-tenant-id');
+        } else if (await page.getByRole('textbox', { name: 'clientID' }).isVisible({ timeout: 3000 }).catch(() => false)) {
+          // Workday generate access token screen — Name, Workday host, clientID, clientSecret
+          await page.getByRole('textbox', { name: 'Name' }).fill('Workday Access Token');
+          await page.getByRole('textbox', { name: 'Workday host' }).fill('https://wd2-impl.workday.com');
+          await page.getByRole('textbox', { name: 'clientID' }).fill('test-client-id');
+          await page.getByRole('textbox', { name: 'clientSecret' }).fill('test-client-secret');
+        } else {
+          // Workday get leavers data screen — Name, Workday host
+          await page.getByRole('textbox', { name: 'Name' }).fill('Workday Get Leavers');
+          await page.getByRole('textbox', { name: 'Workday host' }).fill('https://wd2-impl.workday.com');
+        }
 
-      // Screen 2: Workday generate access token — Name, Workday host, clientID, clientSecret
-      await page.getByRole('textbox', { name: 'Name' }).fill('Workday Access Token');
-      await page.getByRole('textbox', { name: 'Workday host' }).fill('https://wd2-impl.workday.com');
-      await page.getByRole('textbox', { name: 'clientID' }).fill('test-client-id');
-      await page.getByRole('textbox', { name: 'clientSecret' }).fill('test-client-secret');
-      await nextButton.click();
-      await page.waitForLoadState('domcontentloaded').catch(() => {});
-
-      // Screen 3: Setting 3 — tenant IDs, refresh token (Target Groups pre-filled)
-      await page.getByRole('textbox', { name: 'Workday tenant Id (Generate access token)' }).fill('test-tenant-id');
-      await page.getByRole('textbox', { name: 'Refresh token' }).fill('test-refresh-token');
-      await page.getByRole('textbox', { name: 'Workday tenant Id (Get leavers data)' }).fill('test-tenant-id');
-
-      // "Install app" button is visible on Screen 3
+        if (await nextButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+          await nextButton.click();
+          await page.waitForLoadState('domcontentloaded').catch(() => {});
+        }
+      }
     },
   });
 });

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -31,8 +31,8 @@ test.describe('Insider Risk Workday - E2E Tests', () => {
     await workflowsPage.page.getByText('This may take a few moments').first().waitFor({ state: 'hidden', timeout: 30000 });
     await workflowsPage.page.waitForLoadState('domcontentloaded');
 
-    // Verify the action is visible
-    const actionElement = workflowsPage.page.getByText('Workday get leavers data', { exact: false });
+    // Verify the action is visible (use .first() since search input also contains the text)
+    const actionElement = workflowsPage.page.getByText('Workday get leavers data', { exact: false }).first();
     await expect(actionElement).toBeVisible({ timeout: 10000 });
     console.log('✓ API integration action available: Workday get leavers data');
 


### PR DESCRIPTION
Upgrades @crowdstrike/foundry-playwright to 0.5.1, which picks up retry loops for sidebar navigation and CI timing fixes.

Also fixes a strict mode violation in the workflow builder test where `getByText('Workday get leavers data')` resolved to 2 elements (the search input and the result). Adding `.first()` resolves the ambiguity.