### PR TITLE
Upgrade @crowdstrike/foundry-playwright to 0.5.2

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.1",
+        "@crowdstrike/foundry-playwright": "0.5.2",
         "@types/node": "25.6.0"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.1.tgz",
-      "integrity": "sha512-aB74uvvvfrOkHvy3jVfpeO3JPOjPdNHuMR+bUZyqUknFtZ4jBtquQMGWumspbXS+P78vDuI8c8BTVilnI2sscA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.2.tgz",
+      "integrity": "sha512-A69/df/gNVO/WS2aajOTcxIPUWrJiMIaX2e+ePj8LMSMQuYo38VIxnt8wFDNp5RN+RSlhQI1p7svoVJCbVIZOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.1",
+    "@crowdstrike/foundry-playwright": "0.5.2",
     "@types/node": "25.6.0"
   }
 }


### PR DESCRIPTION
Picks up deploy modal timeout fix (10s → 30s) and Change type button disabled state handling, which were previously applied as a monkey-patch in the CI runner. The patch has been removed from foundry-sample-e2e-tests.