### PR TITLE
Remove personal contact email from API integration spec

### DIFF
--- a/api-integrations/Workday_Generate_Access_Token.json
+++ b/api-integrations/Workday_Generate_Access_Token.json
@@ -10,9 +10,6 @@
     }
   },
   "info": {
-    "contact": {
-      "email": "shalabh.sharma@crowdstrike.com"
-    },
     "description": "Workday API generate access_token using refresh_token",
     "title": "Workday generate access token",
     "version": ""

--- a/api-integrations/Workday_Get_Leavers.json
+++ b/api-integrations/Workday_Get_Leavers.json
@@ -1,9 +1,6 @@
 {
   "components": {},
   "info": {
-    "contact": {
-      "email": "shalabh.sharma@crowdstrike.com"
-    },
     "description": "Workday API get leaving employees data",
     "title": "Workday get leavers data",
     "version": ""


### PR DESCRIPTION
## Summary

Removes the `info.contact.email` field from the OpenAPI spec(s) in `api-integrations/`. This field contained a personal CrowdStrike employee email address, which is inappropriate to expose in a public repository.

The field is optional per the OpenAPI specification and is not used by Foundry at runtime.

## Change

- Removed `"contact": { "email": "..." }` block from `info` section
- No functional change — spec behaviour is identical